### PR TITLE
feat: add weight unit preference

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -75,6 +75,7 @@ export interface LastTrainedParties {
 }
 interface UserSettings {
   restDuration: number;
+  weightUnit: "kg" | "lb";
 }
 interface State {
   currentUser: User | null;
@@ -113,6 +114,9 @@ function removeUndefined(obj: any): any {
   return obj;
 }
 
+const defaultWeightUnit =
+  (localStorage.getItem("weightUnit") as "kg" | "lb") || "kg";
+
 const store = createStore<State>({
   state: {
     currentUser: null,
@@ -132,6 +136,7 @@ const store = createStore<State>({
     trainingTimerInterval: null,
     userSettings: {
       restDuration: 120,
+      weightUnit: defaultWeightUnit,
     },
   },
 
@@ -290,6 +295,7 @@ const store = createStore<State>({
     },
     SET_USER_SETTINGS(state, settings: UserSettings) {
       state.userSettings = settings;
+      localStorage.setItem("weightUnit", settings.weightUnit);
     },
   },
 
@@ -397,7 +403,11 @@ const store = createStore<State>({
           trainingHistory: [],
           trainingTemplates: [],
           lastTrainedParties: {},
-          userSettings: { restDuration: 120 },
+          userSettings: {
+            restDuration: 120,
+            weightUnit:
+              (localStorage.getItem("weightUnit") as "kg" | "lb") || "kg",
+          },
         });
         await setDoc(userRef, userData);
         commit("SET_USER", { uid: res.user.uid, email: res.user.email });
@@ -426,7 +436,10 @@ const store = createStore<State>({
       commit("SET_TRAINING_TEMPLATES", []);
       commit("SET_TRAINING_ACTIVE", false);
       commit("SET_LAST_TRAINED_PARTIES", {});
-      commit("SET_USER_SETTINGS", { restDuration: 120 });
+      commit("SET_USER_SETTINGS", {
+        restDuration: 120,
+        weightUnit: (localStorage.getItem("weightUnit") as "kg" | "lb") || "kg",
+      });
     },
     async fetchUserData({ commit, state }) {
       if (state.currentUser) {
@@ -441,7 +454,11 @@ const store = createStore<State>({
           commit("SET_LAST_TRAINED_PARTIES", data.lastTrainedParties || {});
           commit(
             "SET_USER_SETTINGS",
-            data.userSettings || { restDuration: 120 }
+            data.userSettings || {
+              restDuration: 120,
+              weightUnit:
+                (localStorage.getItem("weightUnit") as "kg" | "lb") || "kg",
+            }
           );
         }
       }

--- a/src/utils/weight.ts
+++ b/src/utils/weight.ts
@@ -1,0 +1,20 @@
+export const KG_TO_LB = 2.20462;
+
+export function kgToLb(kg: number): number {
+  return parseFloat((kg * KG_TO_LB).toFixed(2));
+}
+
+export function lbToKg(lb: number): number {
+  return parseFloat((lb / KG_TO_LB).toFixed(2));
+}
+
+export function formatWeight(weight: number | null, unit: "kg" | "lb"): string {
+  if (weight === null) return "0";
+  return unit === "kg" ? weight.toString() : kgToLb(weight).toString();
+}
+
+export function parseWeight(value: string, unit: "kg" | "lb"): number | null {
+  const num = Number(value);
+  if (isNaN(num)) return null;
+  return unit === "kg" ? num : lbToKg(num);
+}

--- a/src/views/ExerciseTypesView.vue
+++ b/src/views/ExerciseTypesView.vue
@@ -96,7 +96,8 @@
                 <ul>
                   <li v-if="type.category === 'strength' && type.lastUsedSets">
                     Serie: {{ type.lastUsedSets.length }}, Max ciężar:
-                    {{ getMaxWeight(type.lastUsedSets) }} kg
+                    {{ formatWeight(getMaxWeight(type.lastUsedSets)) }}
+                    {{ weightUnitLabel }}
                   </li>
                   <li
                     v-if="type.category === 'cardio' && type.lastUsedDuration"
@@ -131,7 +132,11 @@
                   </li>
                   <li v-if="getStats(type.id).category === 'strength'">
                     Rekordowy ciężar:
-                    {{ getStats(type.id).maxWeight || "-" }} kg
+                    <span v-if="getStats(type.id).maxWeight">
+                      {{ formatWeight(getStats(type.id).maxWeight) }}
+                      {{ weightUnitLabel }}
+                    </span>
+                    <span v-else>-</span>
                   </li>
                   <li v-if="getStats(type.id).category === 'strength'">
                     Łącznie serii: {{ getStats(type.id).totalSets || "-" }}
@@ -164,14 +169,16 @@
 <script lang="ts">
 import { defineComponent, ref, computed } from "vue";
 import { useStore } from "vuex";
-import { useRouter } from "vue-router";
 import { ExerciseType, SessionSet, TrainingRecord } from "@/store";
+import { formatWeight as formatWeightUtil } from "@/utils/weight";
 
 export default defineComponent({
   name: "ExerciseTypesView",
   setup() {
     const store = useStore();
-    const router = useRouter();
+    const weightUnitLabel = computed(
+      () => store.getters.userSettings.weightUnit
+    );
 
     const partieMiesniowe = ref([
       "Klatka piersiowa",
@@ -312,6 +319,9 @@ export default defineComponent({
       editType,
       cancelEdit,
       deleteType,
+      weightUnitLabel,
+      formatWeight: (w: number | null) =>
+        formatWeightUtil(w, weightUnitLabel.value),
     };
   },
 });

--- a/src/views/HistoryView.vue
+++ b/src/views/HistoryView.vue
@@ -30,7 +30,8 @@
           class="exercise-details-summary"
         >
           <span v-for="(set, index) in exercise.sets" :key="set.id">
-            {{ index + 1 }}. {{ set.weight || 0 }}kg x {{ set.reps || 0 }} powt.
+            {{ index + 1 }}. {{ formatWeight(set.weight)
+            }}{{ weightUnitLabel }} x {{ set.reps || 0 }} powt.
             {{ set.done ? "(wyk.)" : "(niewyk.)" }}<br />
           </span>
         </span>
@@ -49,6 +50,7 @@ import { defineComponent, computed } from "vue";
 import { useStore } from "vuex";
 import { TrainingRecord } from "@/store";
 import { parseDate } from "@/utils/date";
+import { formatWeight as formatWeightUtil } from "@/utils/weight";
 import TrainingListView from "@/components/TrainingListView.vue";
 
 export default defineComponent({
@@ -58,6 +60,10 @@ export default defineComponent({
   },
   setup() {
     const store = useStore();
+
+    const weightUnitLabel = computed(
+      () => store.getters.userSettings.weightUnit
+    );
 
     const sortedTrainingHistory = computed<TrainingRecord[]>(() => {
       return [...store.getters.allTrainingHistory].sort((a, b) => {
@@ -76,6 +82,9 @@ export default defineComponent({
     return {
       sortedTrainingHistory,
       deleteTraining,
+      formatWeight: (w: number | null) =>
+        formatWeightUtil(w, weightUnitLabel.value),
+      weightUnitLabel,
     };
   },
 });

--- a/src/views/ProfileSettingsView.vue
+++ b/src/views/ProfileSettingsView.vue
@@ -13,6 +13,13 @@
           v-model.number="settings.restDuration"
         />
       </div>
+      <div class="form-group">
+        <label for="weight-unit">Jednostka ciężaru</label>
+        <select id="weight-unit" v-model="settings.weightUnit">
+          <option value="kg">Kilogramy (kg)</option>
+          <option value="lb">Funty (lb)</option>
+        </select>
+      </div>
       <button type="submit" class="action-button primary">Zapisz zmiany</button>
     </form>
   </div>

--- a/src/views/StatsView.vue
+++ b/src/views/StatsView.vue
@@ -50,6 +50,7 @@ import { defineComponent, computed } from "vue";
 import { useStore } from "vuex";
 import { TrainingRecord } from "@/store";
 import { Bar, Line } from "vue-chartjs";
+import { KG_TO_LB } from "@/utils/weight";
 import {
   Chart as ChartJS,
   Title,
@@ -86,6 +87,10 @@ export default defineComponent({
 
     const allTrainingHistory = computed<TrainingRecord[]>(
       () => store.getters.allTrainingHistory
+    );
+    const weightUnit = computed(() => store.getters.userSettings.weightUnit);
+    const conversionFactor = computed(() =>
+      weightUnit.value === "kg" ? 1 : KG_TO_LB
     );
 
     const stats = computed(() => {
@@ -132,7 +137,10 @@ export default defineComponent({
             if (exercise.category === "strength" && exercise.sets) {
               exercise.sets.forEach((set) => {
                 if (set.done) {
-                  totalVolume += (set.weight || 0) * (set.reps || 0);
+                  totalVolume +=
+                    (set.weight || 0) *
+                    conversionFactor.value *
+                    (set.reps || 0);
                 }
               });
             }
@@ -147,7 +155,7 @@ export default defineComponent({
           if (exercise.category === "strength" && exercise.sets) {
             exercise.sets.forEach((set) => {
               const exerciseName = exercise.name;
-              const weight = set.weight || 0;
+              const weight = (set.weight || 0) * conversionFactor.value;
               if (
                 !prWeightsData[exerciseName] ||
                 prWeightsData[exerciseName] < weight
@@ -174,7 +182,7 @@ export default defineComponent({
           labels: uniqueDates,
           datasets: [
             {
-              label: "Objętość siłowa (kg)",
+              label: `Objętość siłowa (${weightUnit.value})`,
               backgroundColor: "#007bff",
               data: strengthVolumeData,
             },
@@ -184,7 +192,7 @@ export default defineComponent({
           labels: Object.keys(prWeightsData),
           datasets: [
             {
-              label: "Najwyższy ciężar (kg)",
+              label: `Najwyższy ciężar (${weightUnit.value})`,
               backgroundColor: "#17a2b8",
               data: Object.values(prWeightsData),
             },

--- a/src/views/TrainingSummaryView.vue
+++ b/src/views/TrainingSummaryView.vue
@@ -15,8 +15,8 @@
           <strong>{{ exercise.name }}</strong>
           <ul v-if="exercise.sets && exercise.sets.length" class="set-list">
             <li v-for="(set, index) in exercise.sets" :key="set.id">
-              Seria {{ index + 1 }}: {{ set.weight || 0 }}kg x
-              {{ set.reps || 0 }} powt.
+              Seria {{ index + 1 }}: {{ formatWeight(set.weight) }}
+              {{ weightUnitLabel }} x {{ set.reps || 0 }} powt.
             </li>
           </ul>
           <p v-else-if="exercise.duration">
@@ -37,6 +37,7 @@ import { defineComponent, computed } from "vue";
 import { useStore } from "vuex";
 import { useRoute, useRouter } from "vue-router";
 import { TrainingRecord } from "@/store";
+import { formatWeight as formatWeightUtil } from "@/utils/weight";
 
 export default defineComponent({
   name: "TrainingSummaryView",
@@ -44,6 +45,9 @@ export default defineComponent({
     const store = useStore();
     const route = useRoute();
     const router = useRouter();
+    const weightUnitLabel = computed(
+      () => store.getters.userSettings.weightUnit
+    );
     const trainingId = route.params.id as string;
 
     const training = computed<TrainingRecord | undefined>(() =>
@@ -59,6 +63,9 @@ export default defineComponent({
     return {
       training,
       goToHistory,
+      weightUnitLabel,
+      formatWeight: (w: number | null) =>
+        formatWeightUtil(w, weightUnitLabel.value),
     };
   },
 });


### PR DESCRIPTION
## Summary
- add weight unit to user settings with localStorage persistence
- allow selecting kilograms or pounds in profile settings
- convert displayed weights to chosen unit across app

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aedae53b50833191fc8e0b80bccd1d